### PR TITLE
Fix message from error thrown by waitFor when failTimeout is exceeded

### DIFF
--- a/src/wait.ts
+++ b/src/wait.ts
@@ -74,7 +74,7 @@ export async function waitFor<T>(
 
       if (now - start > failTimeout) {
         clearTimeout(timer);
-        reject(new Error(`waitFor(${what}) failed after ${timeout} ms`));
+        reject(new Error(`waitFor(${what}) failed after ${failTimeout} ms`));
       }
     });
   });


### PR DESCRIPTION
This fixes an incorrect error message I noticed in lms:

![image](https://github.com/hypothesis/frontend-testing/assets/2719332/d0965994-de53-4d41-bdd8-1d78ba59fcb8)
