### PR TITLE
Wrap components passed to accessibility test in a div

### DIFF
--- a/src/accessibility.tsx
+++ b/src/accessibility.tsx
@@ -20,8 +20,12 @@ async function testScenario(elementOrWrapper: VNode | ReactWrapper) {
 
   let wrapper;
   if (elementOrWrapper instanceof ReactWrapper) {
-    wrapper = elementOrWrapper;
-    container.appendChild(elementOrWrapper.getDOMNode());
+    // Add a div around the wrapper's elements, in case the first element is a
+    // fragment.
+    // This ensures all children are returned when calling wrapper.getDOMNode().
+    // See https://github.com/hypothesis/client/issues/5671
+    wrapper = mount(<div>{elementOrWrapper.getElements()}</div>);
+    container.appendChild(wrapper.getDOMNode());
   } else {
     wrapper = mount(elementOrWrapper, { attachTo: container });
   }

--- a/src/enzyme.d.ts
+++ b/src/enzyme.d.ts
@@ -2,12 +2,19 @@
 // `@types/enzyme` because that brings in all the React types.
 
 declare module 'enzyme' {
+  import type { PreactElement } from 'preact';
+
   export class ReactWrapper {
     getDOMNode(): HTMLElement;
+    getElements(): PreactElement[];
   }
+
+  type MountOptions = {
+    attachTo: HTMLElement;
+  };
 
   export function mount(
     elementOrWrapper: VNode | ReactWrapper,
-    { attachTo: HTMLElement },
+    options?: MountOptions,
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     /* Language and Environment */
     "target": "es2022", 
     "lib": ["dom", "es2022"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
 
     /* Modules */
     "module": "nodenext",


### PR DESCRIPTION
Closes #7 

This PR changes how we mount elements to the DOM in accessibility tests, by making sure they are wrapped in a `<div />` before calling `wrapper.getDOMNode()`.

This ensures all children are always returned, while only the first one is returned when the uppermost element is a Fragment.

I considered doing this conditionally, only when `wrapper.children().length > 1`, which means the uppermost element is a Fragment, but I thought the extra div should not have side effects.

I tested these changes in client, by reverting what we applied in [this PR](https://github.com/hypothesis/client/pull/5672/files), and verified this fixes it.

However, I noticed a couple other tests now fail. They were probably incidentally passing due to the existing bug, when they were in fact wrong.