### PR TITLE
Ensure type declaration files are published with the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "preact": "^10.18.1"
   },
   "files": [
-    "lib/**/*.js"
+    "lib/**/*.js",
+    "lib/**/*.d.ts"
   ],
   "prettier": {
     "arrowParens": "avoid",


### PR DESCRIPTION
We don't yet need, as we currently write all tests in JS format, but this will be needed to import from `@hypothesis/frontend-testing` in tests written in TS.