### PR TITLE
Avoid reference to src/enzyme.d.ts in lib type definitions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,10 @@
     "strict": true,
 
     /* Completeness */
-    "skipLibCheck": true
+    "skipLibCheck": true,
+
+    "paths": {
+      "enzyme": ["./src/enzyme.d.ts"]
+    }
   }
 }


### PR DESCRIPTION
I noticed that, when building this library with `tsc`, the definition type for the accessibility module ended up with a Triple-Slash Directive referencing the `enzyme.d.ts` file from src:

![image](https://github.com/hypothesis/frontend-testing/assets/2719332/0bcd3f98-1b99-424a-9d60-f48839935fba)

That caused an error in downstream projects, as that file is not shipped with the library.

This PR adds a path remapping in `tsconfig.json` that causes this directive to not be added to the type definition, preventing that error.

Before this approach, I also tried multiple combinations of `"include"`, `"exclude"` and `"types"`, and all ended up breaking other things.

I even considered having a different `tsconfig.build.json` file for building. This is a relatively common practice, but I have always found it cumbersome and tried to avoid it.

Adding the paths prevents other side effects while solving this problem, and since this package already depends on `enzyme`, we know the symbols will be available when running tests.

### Testing steps:

1. Go to `main` branch
2. Run `yarn install --immutable`
3. Run `yarn build`: You should see a `lib/accessibility.d.ts` file (among others) with `/// <reference path="../src/enzyme.d.ts" />` as the very first line. 
4. Check out this branch nd repeat steps 2 and 3: The `lib/accessibility.d.ts` file should no longer have that directive.