### PR TITLE
Add container element to `document.body`

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -25,6 +25,9 @@ export function mount(jsx: VNode, { connected = false }: MountOptions = {}) {
     const container = document.createElement('div');
     container.setAttribute('data-enzyme-container', '');
     containers.push(container);
+
+    document.body.append(container);
+
     wrapper = enzyme.mount(jsx, { attachTo: container });
   } else {
     wrapper = enzyme.mount(jsx);


### PR DESCRIPTION
Make the `mount` function actually add the container to the document body, as described in the API docs.