### PR TITLE
Improve comment for MountOptions.prepareContainer

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -13,8 +13,8 @@ export type MountOptions = {
   connected?: boolean;
 
   /**
-   * When `connected` is true, allows to customize the container to which the
-   * wrapper is connected to.
+   * When `connected` is true, allows customizing the DOM container in which the
+   * component is mounted.
    * Useful to add custom styles and such.
    */
   prepareContainer?: (container: HTMLElement) => void;


### PR DESCRIPTION
Improving comment for `MountOptions.prepareContainer` as suggested in [this comment](https://github.com/hypothesis/frontend-testing/pull/59#discussion_r1865971260).