### PR TITLE
Improve Enzyme's type declaration

### DIFF
--- a/src/enzyme.d.ts
+++ b/src/enzyme.d.ts
@@ -2,9 +2,44 @@
 // `@types/enzyme` because that brings in all the React types.
 
 declare module 'enzyme' {
-  export class ReactWrapper {
+  import { ComponentClass, FunctionComponent } from 'preact';
+
+  export interface EnzymePropSelector {
+    [key: string]: any;
+  }
+
+  export type EnzymeSelector =
+    | string
+    | FunctionComponent<any>
+    | ComponentClass<any>
+    | EnzymePropSelector;
+
+  export class ReactWrapper<P = {}, S = {}, C = Component> {
+    at(index: number): this;
+    exists(selector?: EnzymeSelector): boolean;
+
+    find<P2>(
+      statelessComponent: FunctionComponent<P2>,
+    ): ReactWrapper<P2, never>;
+    find<P2>(component: ComponentType<P2>): ReactWrapper<P2, any>;
+    find<C2 extends Component>(
+      componentClass: ComponentClass<C2['props']>,
+    ): ReactWrapper<C2['props'], C2['state'], C2>;
+    find(props: EnzymePropSelector): ReactWrapper<any, any>;
+    find(selector: string): ReactWrapper<HTMLAttributes, any>;
+
+    forEach(fn: (wrapper: this, index: number) => any): this;
     getDOMNode(): HTMLElement;
+    instance(): C;
+    length: number;
+    prop<K extends keyof P>(key: K): P[K];
+    prop<T>(key: string): T;
+    props(): P;
+    setProps<K extends keyof P>(props: Pick<P, K>, callback?: () => void): this;
+    simulate(event: string, ...args: any[]): this;
+    text(): string;
     unmount(): void;
+    update(): this;
   }
 
   export function mount(


### PR DESCRIPTION
Improve a bit our `ReactWrapper` definition based on the methods/properties we use and [definitely typed definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cebb88fecfa52f854826e216a537867c11b0150e/types/enzyme/index.d.ts).

The official definition has more stuff, but I decided to keep it simple as a POC. I checked which methods we use in `client`, but we may need to enhance this definition based on the usage in other projects.

### Considerations

We are currently not shipping these types with the library, but we probably should, otherwise downstream code won't benefit of these changes.