### PR TITLE
Expose custom return type for our mount function

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -1,6 +1,6 @@
 import * as enzyme from 'enzyme';
 import type { ReactWrapper } from 'enzyme';
-import type { VNode } from 'preact';
+import { FunctionComponent, JSX, VNode } from 'preact';
 
 let containers: HTMLElement[] = [];
 let wrappers: ReactWrapper[] = [];
@@ -20,16 +20,52 @@ export type MountOptions = {
   prepareContainer?: (container: HTMLElement) => void;
 };
 
+export type EnzymeSelector = string | FunctionComponent<any>;
+
+/**
+ * Inspired by DefinitelyTyped's ReactWrapper.
+ * @see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cebb88fecfa52f854826e216a537867c11b0150e/types/enzyme/index.d.ts
+ */
+export type ComponentWrapper<P = {}, S = {}> = {
+  at(index: number): ComponentWrapper;
+  childAt(index: number): ComponentWrapper<any, any>;
+
+  closest<P2>(component: FunctionComponent<P2>): ComponentWrapper<P2, any>;
+  closest(selector: string): ComponentWrapper<JSX.HTMLAttributes, any>;
+
+  exists(selector?: EnzymeSelector): boolean;
+
+  find<P2>(component: FunctionComponent<P2>): ComponentWrapper<P2, any>;
+  find(selector: string): ComponentWrapper<JSX.HTMLAttributes, any>;
+
+  first(): ComponentWrapper<P, S>;
+  forEach(
+    fn: (wrapper: ComponentWrapper<P, S>, index: number) => any,
+  ): ComponentWrapper<P, S>;
+  getDOMNode(): HTMLElement;
+  hasClass(className: string | RegExp): boolean;
+  last(): ComponentWrapper<P, S>;
+  length: number;
+  map<V>(fn: (wrapper: ComponentWrapper<P, S>, index: number) => V): V[];
+  prop<K extends keyof P>(key: K): P[K];
+  props(): P;
+  setProps<K extends keyof P>(props: Pick<P, K>): ComponentWrapper<P, S>;
+  simulate(event: string, ...args: any[]): ComponentWrapper<P, S>;
+  text(): string;
+  unmount(): void;
+  update(): ComponentWrapper<P, S>;
+};
+
 /**
  * Render a Preact component using Enzyme and return a wrapper.
  *
  * The component can be unmounted by calling `wrapper.unmount()` or by calling
  * {@link unmountAll} at the end of the test.
  */
-export function mount(
+export function mount<P = {}, S = {}>(
   jsx: VNode,
   { connected = false, prepareContainer }: MountOptions = {},
-) {
+): ComponentWrapper<P, S> {
   let wrapper;
   if (connected) {
     const container = document.createElement('div');
@@ -46,7 +82,7 @@ export function mount(
 
   wrappers.push(wrapper);
 
-  return wrapper;
+  return wrapper as ComponentWrapper<P, S>;
 }
 
 /**


### PR DESCRIPTION
> Supersedes https://github.com/hypothesis/frontend-testing/pull/62

Add a custom type definition for the objects returned by our `mount()` function.

The type is based on the "official" enzyme [types from DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cebb88fecfa52f854826e216a537867c11b0150e/types/enzyme/index.d.ts), but ignoring `ShallowWrapper` and the methods we don't use from `ReactWrapper`.

I also decided to name the main type `ComponentWrapper`, to avoid coupling the name with a specific UI framework, but I don't have a strong opinion about this name.

I checked `client`, `frontend-shared`, `lms`, `h` and `via` to see what parts of the wrapper object were already in use, and defined them here.

I also tested this via yalc in client project, and verified my IDE is now smarter about code autocompletion.