### PR TITLE
Remove re-exporting of vitest symbols from main entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This library provides these options for convenience, so that you don't need to
 define them everywhere.
 
 ```js
-import { vitestCoverageOptions } from '@hypothesis/frontend-testing';
+import { vitestCoverageOptions } from '@hypothesis/frontend-testing/vitest';
 import { babel } from '@rollup/plugin-babel';
 
 const babelRollupPlugin = babel({
@@ -132,7 +132,7 @@ still prints the real-time summary and details for any failed test.
 
 ```js
 // vitest.config.js
-import { SummaryReporter } from '@hypothesis/frontend-testing';
+import { SummaryReporter } from '@hypothesis/frontend-testing/vitest';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,5 @@ export { checkAccessibility } from './accessibility.js';
 export { mockImportedComponents } from './mock-imported-components.js';
 export { mount, unmountAll } from './mount.js';
 export type { MountOptions } from './mount.js';
-export { SummaryReporter, vitestCoverageOptions } from './vitest.js';
 export type { TestTimeout, TimeoutSpec } from './wait.js';
 export { delay, waitFor, waitForElement } from './wait.js';


### PR DESCRIPTION
This PR rolls back a change from https://github.com/hypothesis/frontend-testing/pull/81, where all vitest-related utils were re-exported from the main entry point, causing Rollup to fail to bundle tests, as vitest expects to be run in a Node.js env, not a browser.

We'll have to keep a dedicated `@hypothesis/frontend-testing/vitest` entry point around for those symbols.